### PR TITLE
Strip forwarded email blocks (gmail)

### DIFF
--- a/lib/bruteforce.js
+++ b/lib/bruteforce.js
@@ -146,6 +146,7 @@ var EMAIL_SERVICE_PROVIDERS = {
   }
 };
 
+var FORWARD_EMAIL_BLOCK = /---------- Forwarded message(.*)\nFrom:(.*)\nDate:(.*)\nSubject:(.*)\nTo:(.*)/im;
 
 /* from original lib
     Analyzes message for a presence of signature block (by common patterns)
@@ -171,6 +172,8 @@ function extractSignature (msgBody) {
       strippedBody = strippedBody.replace(
         emailServiceProvider.RE_ENG_FOOTER_TEXT, '');
     });
+
+    strippedBody = strippedBody.replace(FORWARD_EMAIL_BLOCK, '');
 
     // strip off phone signature (get last one)
     var match = msgBody.match(RE_PHONE_SIGNATURE);

--- a/test/signature-bruteforce.js
+++ b/test/signature-bruteforce.js
@@ -207,6 +207,21 @@ describe("signature.bruteforce", function () {
 
   });
 
+  describe("Forwarded email block stripping", function() {
+    it("should ignore forwarded email blocks", function () {
+      testExtract("---------- Forwarded message ----------\nFrom: Marissa Montgomery <m@m15y.com>\n" +
+        "Date: Wed, Nov 15, 2017 at 3:13 PM\nSubject: hey\nTo: marissa@askspoke.com\n\nintern hiring?",
+        "intern hiring?", null);
+      testExtract("---------- Forwarded message ----------\nFrom: Marissa Montgomery <m@m15y.com>\n" +
+        "Date: Wed, Nov 15, 2017 at 3:13 PM\nSubject: hey\nTo: marissa@askspoke.com\n\nintern hiring?\n\n---\nRoman",
+        "intern hiring?", "---\nRoman");
+      testExtract("---------- Forwarded message ----------\nFrom:\nDate:\nSubject:\nTo:", "", null);
+      testExtract("and second bit of text\n---------- Forwarded message ----------\nFrom: Marissa Montgomery <m@m15y.com>\n" +
+        "Date: Thu, Nov 16, 2017 at 11:46 AM\nSubject: hey\nTo: marissa@askspoke.com\nfirst bit of text\n-- \nMarissa Montgomery\nTest signature 3",
+        "and second bit of text\n\nfirst bit of text", "-- \nMarissa Montgomery\nTest signature 3");
+    });
+  });
+
   describe("Ignores Google group footer", function () {
     var googleFooter =
     ['You received this message because you are subscribed to the Google Groups "pplocal" group.',


### PR DESCRIPTION
Fixes https://github.com/askspoke/spoke/issues/5321

Will get the two user-typed text lines from this email:

<img width="404" alt="screen shot 2017-11-16 at 11 56 26 am" src="https://user-images.githubusercontent.com/1459660/32912863-4578d372-cac5-11e7-8024-97ba432d26fc.png">
